### PR TITLE
Add JSON feed processing

### DIFF
--- a/.github/workflows/feed_bot.yml
+++ b/.github/workflows/feed_bot.yml
@@ -51,7 +51,6 @@ jobs:
         env:
           GALAXY_SOCIAL_BOT_TOKEN: ${{ steps.generate-token.outputs.token }}
           REPO: "usegalaxy-eu/galaxy-social"
-          DAYS: ${{ github.event.inputs.days || '14' }}
         run: python -u app/json_bot.py
 
   keepalive-job:

--- a/.github/workflows/feed_bot.yml
+++ b/.github/workflows/feed_bot.yml
@@ -40,12 +40,19 @@ jobs:
           owner: "usegalaxy-eu"
           repositories: "galaxy-social"
 
-      - name: Run python script
+      - name: Run python script for RSS/Atom feeds
         env:
           GALAXY_SOCIAL_BOT_TOKEN: ${{ steps.generate-token.outputs.token }}
           REPO: "usegalaxy-eu/galaxy-social"
           DAYS: ${{ github.event.inputs.days || '14' }}
         run: python -u app/feed_bot.py
+
+      - name: Run python script for json feeds
+        env:
+          GALAXY_SOCIAL_BOT_TOKEN: ${{ steps.generate-token.outputs.token }}
+          REPO: "usegalaxy-eu/galaxy-social"
+          DAYS: ${{ github.event.inputs.days || '14' }}
+        run: python -u app/json_bot.py
 
   keepalive-job:
     name: Keepalive Workflow

--- a/app/json_bot.py
+++ b/app/json_bot.py
@@ -46,6 +46,10 @@ def main():
                 protocol = "http://"
             entry["link"] = protocol + url.split("/")[0] + path
 
+            if entry.get("days_ago") > 0:
+                print(f"Skipping {entry.get('title')}")
+                continue
+
             formatted_text = format_string.format(**entry)
 
             entry_data = {

--- a/app/json_bot.py
+++ b/app/json_bot.py
@@ -1,0 +1,63 @@
+import json
+import os
+
+import requests
+from dateutil import parser
+from utils import utils
+
+
+def main():
+    json_feed_bot_path = os.environ.get("JSON_BOT_PATH", "posts/json_bot")
+    config_name = "json_feeds"
+    utils_obj = utils(json_feed_bot_path, config_name)
+
+    for feed in utils_obj.list:
+        url = feed.get("url")
+        if url is None:
+            raise ValueError(f"No url found in the file for feed {feed}")
+        try:
+            response = requests.get(url).content.decode("utf-8")
+            feed_data = json.loads(response)
+        except Exception as e:
+            print(f"Error in parsing feed {feed.get('url')}: {e}")
+            continue
+
+        if feed.get("title") is None:
+            raise ValueError(f"No title found in the file for feed {feed}")
+        if feed.get("list_key") is None:
+            raise ValueError(f"No list_key found in the file for feed {feed}")
+
+        folder = feed.get("title").replace(" ", "_").lower()
+        format_string = feed.get("format")
+        for entry in feed_data.get(feed.get("list_key"), []):
+            date_entry = entry.get("date")
+            published_date = parser.parse(date_entry).date()
+
+            path = entry.get("path")
+            if path is None:
+                print(f"No path found: {entry.get('title')}")
+                continue
+            file_name = path.rstrip("/").split("/")[-1]
+
+            if "://" in url:
+                protocol = url.split("://")[0] + "://"
+                url = url.split("://")[1]
+            else:
+                protocol = "http://"
+            entry["link"] = protocol + url.split("/")[0] + path
+
+            formatted_text = format_string.format(**entry)
+
+            entry_data = {
+                "title": entry.get("title"),
+                "config": feed,
+                "date": published_date,
+                "rel_file_path": f"{folder}/{file_name}",
+                "formatted_text": formatted_text,
+                "link": entry["link"],
+            }
+            utils_obj.process_entry(entry_data)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/utils.py
+++ b/app/utils.py
@@ -51,10 +51,11 @@ class utils:
         ):
             self.existing_files.add(pr.title)
 
-        self.start_date = datetime.now().date() - timedelta(
-            days=int(os.environ.get("DAYS", 1))
-        )
-        print(f"Processing items since {self.start_date}.")
+        self.start_date = None
+        days = os.environ.get("DAYS")
+        if days:
+            self.start_date = datetime.now().date() - timedelta(days=int(days))
+            print(f"Processing items since {self.start_date}.")
 
     def process_entry(self, entry):
         title = entry.get("title")
@@ -66,9 +67,10 @@ class utils:
 
         file_path = f"{self.bot_path}/{rel_file_path}"
 
-        if date < self.start_date:
-            print(f"Skipping as it is older: {title}")
-            return False
+        if self.start_date:
+            if date < self.start_date:
+                print(f"Skipping as it is older: {title}")
+                return False
 
         if any(link in pr_title for pr_title in self.existing_files):
             print(f"Skipping as file already exists: {file_path} for {title}")
@@ -105,10 +107,14 @@ class utils:
                 )
 
         pr_title = f"Update from {self.item_type}: {link}"
+        update_date = (
+            f"Update since {self.start_date.strftime('%Y-%m-%d')}\n\n"
+            if self.start_date
+            else ""
+        )
         pr_body = (
             f"This PR is created automatically by a {self.item_type} bot.\n"
-            f"Update since {self.start_date.strftime('%Y-%m-%d')}\n\n"
-            f"Processed:\n[{title}]({link})"
+            f"{update_date}Processed:\n[{title}]({link})"
         )
 
         try:

--- a/config.yml
+++ b/config.yml
@@ -40,6 +40,46 @@ feeds:
         - EOSC
         - EuroScienceGateway
 
+json_feeds:
+  - title: "Galaxy Events"
+    url: https://galaxyproject.org/events/feed.json
+    list_key: "events"
+    format: "- {title}\n- {date}\n- {link}"
+
+    media:
+      - group1:
+        - mastodon-eu-freiburg
+        - matrix-eu-announce
+        - linkedin-galaxyproject
+      - group2:
+        - bluesky-galaxyproject
+
+    mentions:
+      mastodon-eu-freiburg:
+        - galaxyproject@mstdn.science
+      bluesky-galaxyproject:
+        - galaxyproject.bsky.social
+
+    hashtags:
+      mastodon-eu-freiburg:
+        - UseGalaxy
+        - GalaxyProject
+        - UniFreiburg
+        - EOSC
+        - EuroScienceGateway
+      bluesky-galaxyproject:
+        - UseGalaxy
+        - GalaxyProject
+        - UniFreiburg
+        - EOSC
+        - EuroScienceGateway
+      linkedin-galaxyproject:
+        - UseGalaxy
+        - GalaxyProject
+        - UniFreiburg
+        - EOSC
+        - EuroScienceGateway
+
 # youtube_channels:
 #   - channel: "https://www.youtube.com/c/galaxyproject"
 #     format: "🎥 New YouTube Video Released!\n\n{title}\n\n🔗 Watch it now: {link}"


### PR DESCRIPTION
Introduce functionality to process JSON feeds, including a new script and configuration for handling feed data. This enhancement allows for better integration of JSON-based content into the existing system.

As requested in https://github.com/usegalaxy-eu/galaxy-social/issues/213, after the PR has been merged it will retrive **ALL** the events that are not passed from https://galaxyproject.org/events/feed.json and send new events to the galaxy social bot as new PRs.