### PR TITLE
Add json feed bot

### DIFF
--- a/.github/workflows/feed_bot.yml
+++ b/.github/workflows/feed_bot.yml
@@ -51,7 +51,6 @@ jobs:
         env:
           GALAXY_SOCIAL_BOT_TOKEN: ${{ steps.generate-token.outputs.token }}
           REPO: "usegalaxy-eu/galaxy-social"
-          DAYS: ${{ github.event.inputs.days || '14' }}
         run: python -u app/json_bot.py
 
   keepalive-job:

--- a/.github/workflows/feed_bot.yml
+++ b/.github/workflows/feed_bot.yml
@@ -10,6 +10,10 @@ on:
         description: "Number of days before today to check for new feeds"
         required: false
         default: "14"
+      update:
+        description: "Update the open PRs with new json formats"
+        required: false
+        type: boolean
 
 jobs:
   feed-bot:
@@ -51,6 +55,7 @@ jobs:
         env:
           GALAXY_SOCIAL_BOT_TOKEN: ${{ steps.generate-token.outputs.token }}
           REPO: "usegalaxy-eu/galaxy-social"
+          UPDATE: ${{ github.event.inputs.update || 'false' }}
         run: python -u app/json_bot.py
 
   keepalive-job:

--- a/.github/workflows/feed_bot.yml
+++ b/.github/workflows/feed_bot.yml
@@ -40,12 +40,19 @@ jobs:
           owner: "usegalaxy-eu"
           repositories: "galaxy-social"
 
-      - name: Run python script
+      - name: Run python script for RSS/Atom feeds
         env:
           GALAXY_SOCIAL_BOT_TOKEN: ${{ steps.generate-token.outputs.token }}
           REPO: "usegalaxy-eu/galaxy-social"
           DAYS: ${{ github.event.inputs.days || '14' }}
         run: python -u app/feed_bot.py
+
+      - name: Run python script for json feeds
+        env:
+          GALAXY_SOCIAL_BOT_TOKEN: ${{ steps.generate-token.outputs.token }}
+          REPO: "usegalaxy-eu/galaxy-social"
+          DAYS: ${{ github.event.inputs.days || '14' }}
+        run: python -u app/json_bot.py
 
   keepalive-job:
     name: Keepalive Workflow

--- a/.github/workflows/feed_bot.yml
+++ b/.github/workflows/feed_bot.yml
@@ -1,4 +1,4 @@
-name: Create PR for RSS/Atom feeds
+name: Create PR for RSS/Atom or json feeds
 
 on:
   schedule:

--- a/.github/workflows/feed_bot.yml
+++ b/.github/workflows/feed_bot.yml
@@ -64,5 +64,12 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: gautamkrishnar/keepalive-workflow@v2
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Keep the repository alive
+        run: |
+          echo "Keep-alive job executed at $(date)" > keepalive.log
+          git add keepalive.log
+          git commit -m "Update keepalive log"
+          git push

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This bot automatically creates posts on Galaxy Social by adding pull requests to
 ## Currently Supported Inputs
 
 * RSS and Atom feeds
+* JSON feeds from Galaxy Project
 * YouTube
 * Citations from Zotero
 

--- a/app/feed_bot.py
+++ b/app/feed_bot.py
@@ -43,6 +43,12 @@ def main():
             # collapse 2 and more empty lines into one
             entry["content"] = re.sub(r"\n{3,}", "\n\n", entry["content"])
 
+            entry["images"] = ""
+            if "content" in entry:
+                entry["images"] = "\n".join(
+                    re.findall(r"!\[.*?\]\(.*?\)", entry["content"])
+                )
+
             formatted_text = format_string.format(**entry)
 
             entry_data = {

--- a/app/json_bot.py
+++ b/app/json_bot.py
@@ -27,9 +27,19 @@ def main():
         if feed.get("list_key") is None:
             raise ValueError(f"No list_key found in the file for feed {feed}")
 
+        subsites = feed.get("subsites")
+
         folder = feed.get("title").replace(" ", "_").lower()
         format_string = feed.get("format")
         for entry in feed_data.get(feed.get("list_key"), []):
+            if (
+                subsites
+                and isinstance(subsites, list)
+                and not any(subsite in entry.get("subsites") for subsite in subsites)
+            ):
+                print(f"Skipping {entry.get('title')} as it is not in the subsites")
+                continue
+
             date_entry = entry.get("date")
             published_date = parser.parse(date_entry).date()
 

--- a/app/json_bot.py
+++ b/app/json_bot.py
@@ -47,7 +47,13 @@ def main():
             entry["link"] = protocol + url.split("/")[0] + path
 
             if entry.get("days_ago") > 0:
-                print(f"Skipping {entry.get('title')}")
+                print(f"Skipping {entry.get('title')} as it is past the date")
+                continue
+
+            if entry.get("days_ago") < -14:
+                print(
+                    f"Skipping {entry.get('title')} as it is more than 14 days till now"
+                )
                 continue
 
             formatted_text = format_string.format(**entry)

--- a/app/json_bot.py
+++ b/app/json_bot.py
@@ -39,22 +39,26 @@ def main():
                 continue
             file_name = path.rstrip("/").split("/")[-1]
 
-            if "://" in url:
-                protocol = url.split("://")[0] + "://"
-                url = url.split("://")[1]
+            if "external_link" in entry:
+                entry["link"] = entry["external_link"]
             else:
-                protocol = "http://"
-            entry["link"] = protocol + url.split("/")[0] + path
+                if "://" in url:
+                    protocol = url.split("://")[0] + "://"
+                    url = url.split("://")[1]
+                else:
+                    protocol = "http://"
+                entry["link"] = protocol + url.split("/")[0] + path
 
-            if entry.get("days_ago") > 0:
-                print(f"Skipping {entry.get('title')} as it is past the date")
-                continue
+            if feed.get("list_key") == "events":
+                if entry.get("days_ago") > 0:
+                    print(f"Skipping {entry.get('title')} as it is past the date")
+                    continue
 
-            if entry.get("days_ago") < -14:
-                print(
-                    f"Skipping {entry.get('title')} as it is more than 14 days till now"
-                )
-                continue
+                if entry.get("days_ago") < -14:
+                    print(
+                        f"Skipping {entry.get('title')} as it is more than 14 days till now"
+                    )
+                    continue
 
             formatted_text = format_string.format(**entry)
 

--- a/app/json_bot.py
+++ b/app/json_bot.py
@@ -19,29 +19,29 @@ def main():
             response = requests.get(url).content.decode("utf-8")
             feed_data = json.loads(response)
         except Exception as e:
-            print(f"Error in parsing feed {feed.get('url')}: {e}")
+            print(f"Error in parsing feed {url}: {e}")
             continue
 
-        if feed.get("title") is None:
+        feed_title = feed.get("title")
+        feed_list_key = feed.get("list_key")
+        if feed_title is None:
             raise ValueError(f"No title found in the file for feed {feed}")
-        if feed.get("list_key") is None:
+        if feed_list_key is None:
             raise ValueError(f"No list_key found in the file for feed {feed}")
 
-        subsites = feed.get("subsites")
-
-        folder = feed.get("title").replace(" ", "_").lower()
+        folder = feed_title.replace(" ", "_").lower()
         format_string = feed.get("format")
-        for entry in feed_data.get(feed.get("list_key"), []):
-            if (
-                subsites
-                and isinstance(subsites, list)
-                and not any(subsite in entry.get("subsites") for subsite in subsites)
-            ):
+        media_data = feed.get("media")
+        mentions_data = feed.get("mentions")
+        hashtags_data = feed.get("hashtags")
+
+        for entry in feed_data.get(feed_list_key, []):
+            entry_subsites = entry.get("subsites")
+            if not any(subsite in entry_subsites for subsite in media_data.keys()):
                 print(f"Skipping {entry.get('title')} as it is not in the subsites")
                 continue
 
-            date_entry = entry.get("date")
-            published_date = parser.parse(date_entry).date()
+            published_date = parser.parse(entry.get("date")).date()
 
             path = entry.get("path")
             if path is None:
@@ -57,13 +57,13 @@ def main():
                     url = url.split("://")[1]
                 else:
                     protocol = "http://"
+                path = path if path.startswith("/") else f"/{path}"
                 entry["link"] = protocol + url.split("/")[0] + path
 
-            if feed.get("list_key") == "events":
+            if feed_list_key == "events":
                 if entry.get("days_ago") > 0:
                     print(f"Skipping {entry.get('title')} as it is past the date")
                     continue
-
                 if entry.get("days_ago") < -14:
                     print(
                         f"Skipping {entry.get('title')} as it is more than 14 days till now"
@@ -72,13 +72,45 @@ def main():
 
             formatted_text = format_string.format(**entry)
 
+            new_media = {}
+            for subsite, content in media_data.items():
+                if subsite not in entry_subsites:
+                    continue
+                if isinstance(content, dict):
+                    for group_name, media_list in content.items():
+                        new_media[f"{subsite}_{group_name}"] = media_list
+                elif isinstance(content, list):
+                    new_media[subsite] = content
+
+            used_media_names = set()
+            for media_list in new_media.values():
+                used_media_names.update(media_list)
+
+            def map_config(feed_config):
+                new_config = {}
+                feed_config_all = feed_config.get("all", {})
+                for media in used_media_names:
+                    if media in feed_config_all:
+                        new_config[media] = feed_config_all[media].copy()
+                for subsite in entry_subsites:
+                    for media, value in feed_config.get(subsite, {}).items():
+                        if media in used_media_names:
+                            new_config.setdefault(media, []).extend(value)
+                return new_config
+
+            json_config = {
+                "media": new_media,
+                "mentions": map_config(mentions_data),
+                "hashtags": map_config(hashtags_data),
+            }
+
             entry_data = {
                 "title": entry.get("title"),
-                "config": feed,
+                "config": json_config,
                 "date": published_date,
                 "rel_file_path": f"{folder}/{file_name}",
                 "formatted_text": formatted_text,
-                "link": entry["link"],
+                "link": entry.get("link"),
             }
             utils_obj.process_entry(entry_data)
 

--- a/app/json_bot.py
+++ b/app/json_bot.py
@@ -46,6 +46,10 @@ def main():
                 protocol = "http://"
             entry["link"] = protocol + url.split("/")[0] + path
 
+            if entry.get("days_ago") > 0:
+                print(f"Skipping {entry.get('title')}")
+                continue
+
             formatted_text = format_string.format(**entry)
 
             entry_data = {

--- a/app/json_bot.py
+++ b/app/json_bot.py
@@ -1,0 +1,63 @@
+import json
+import os
+
+import requests
+from dateutil import parser
+from utils import utils
+
+
+def main():
+    json_feed_bot_path = os.environ.get("JSON_BOT_PATH", "posts/json_bot")
+    config_name = "json_feeds"
+    utils_obj = utils(json_feed_bot_path, config_name)
+
+    for feed in utils_obj.list:
+        url = feed.get("url")
+        if url is None:
+            raise ValueError(f"No url found in the file for feed {feed}")
+        try:
+            response = requests.get(url).content.decode("utf-8")
+            feed_data = json.loads(response)
+        except Exception as e:
+            print(f"Error in parsing feed {feed.get('url')}: {e}")
+            continue
+
+        if feed.get("title") is None:
+            raise ValueError(f"No title found in the file for feed {feed}")
+        if feed.get("list_key") is None:
+            raise ValueError(f"No list_key found in the file for feed {feed}")
+
+        folder = feed.get("title").replace(" ", "_").lower()
+        format_string = feed.get("format")
+        for entry in feed_data.get(feed.get("list_key"), []):
+            date_entry = entry.get("date")
+            published_date = parser.parse(date_entry).date()
+
+            path = entry.get("path")
+            if path is None:
+                print(f"No path found: {entry.get('title')}")
+                continue
+            file_name = path.rstrip("/").split("/")[-1]
+
+            if "://" in url:
+                protocol = url.split("://")[0] + "://"
+                url = url.split("://")[1]
+            else:
+                protocol = "http://"
+            entry["link"] = protocol + url.split("/")[0] + path
+
+            formatted_text = format_string.format(**entry)
+
+            entry_data = {
+                "title": entry.get("title"),
+                "config": feed,
+                "date": published_date,
+                "rel_file_path": f"{folder}/{file_name}",
+                "formatted_text": formatted_text,
+                "link": entry["link"],
+            }
+            utils_obj.process_entry(entry_data)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/utils.py
+++ b/app/utils.py
@@ -51,10 +51,11 @@ class utils:
         ):
             self.existing_files.add(pr.title)
 
-        self.start_date = datetime.now().date() - timedelta(
-            days=int(os.environ.get("DAYS", 1))
-        )
-        print(f"Processing items since {self.start_date}.")
+        self.start_date = None
+        days = os.environ.get("DAYS")
+        if days:
+            self.start_date = datetime.now().date() - timedelta(days=int(days))
+            print(f"Processing items since {self.start_date}.")
 
     def process_entry(self, entry):
         title = entry.get("title")
@@ -66,9 +67,10 @@ class utils:
 
         file_path = f"{self.bot_path}/{rel_file_path}"
 
-        if date < self.start_date:
-            print(f"Skipping as it is older: {title}")
-            return False
+        if self.start_date:
+            if date < self.start_date:
+                print(f"Skipping as it is older: {title}")
+                return False
 
         if any(link in pr_title for pr_title in self.existing_files):
             print(f"Skipping as file already exists: {file_path} for {title}")
@@ -105,10 +107,14 @@ class utils:
                 )
 
         pr_title = f"Update from {self.item_type}: {link}"
+        update_date = (
+            f"Update since {self.start_date.strftime('%Y-%m-%d')}\n\n"
+            if self.start_date
+            else ""
+        )
         pr_body = (
             f"This PR is created automatically by a {self.item_type} bot.\n"
-            f"Update since {self.start_date.strftime('%Y-%m-%d')}\n\n"
-            f"Processed:\n[{title}]({link})"
+            f"{update_date}Processed:\n[{title}]({link})"
         )
 
         try:

--- a/app/utils.py
+++ b/app/utils.py
@@ -83,27 +83,24 @@ class utils:
             sha=self.repo.get_branch("main").commit.sha,
         )
 
-        for media_group in config.get("media", []):
-            conf_media = list(media_group.values())[0]
-            if isinstance(conf_media, list):
-                config_dict = {"media": conf_media}
-                for key in ["mentions", "hashtags"]:
-                    for media in conf_media:
-                        if config.get(key) and config[key].get(media):
-                            if key not in config_dict:
-                                config_dict[key] = {}
-                            config_dict[key][media] = config[key][media]
+        for group_name, media_list in config.get("media", {}).items():
+            config_dict = {"media": media_list}
+            for key in ["mentions", "hashtags"]:
+                for media in media_list:
+                    if config.get(key) and config[key].get(media):
+                        if key not in config_dict:
+                            config_dict[key] = {}
+                        config_dict[key][media] = config[key][media]
 
-                md_config = yaml.dump(config_dict, sort_keys=False)
+            md_config = yaml.dump(config_dict, sort_keys=False)
+            md_content = f"---\n{md_config}---\n{formatted_text}"
 
-                md_content = f"---\n{md_config}---\n{formatted_text}"
-
-                self.repo.create_file(
-                    path=f"{file_path}-{'_'.join(media_group)}.md",
-                    message=f"Add {title} for {', '.join(media_group)}",
-                    content=md_content,
-                    branch=branch_name,
-                )
+            self.repo.create_file(
+                path=f"{file_path}-{group_name}.md",
+                message=f"Add {title} for {', '.join(media_list)}",
+                content=md_content,
+                branch=branch_name,
+            )
 
         pr_title = f"Update from {self.item_type}: {link}"
         update_date = (

--- a/app/utils.py
+++ b/app/utils.py
@@ -67,10 +67,9 @@ class utils:
 
         file_path = f"{self.bot_path}/{rel_file_path}"
 
-        if self.start_date:
-            if date < self.start_date:
-                print(f"Skipping as it is older: {title}")
-                return False
+        if self.start_date and date < self.start_date:
+            print(f"Skipping as it is older: {title}")
+            return False
 
         if any(link in pr_title for pr_title in self.existing_files):
             print(f"Skipping as file already exists: {file_path} for {title}")

--- a/app/utils.py
+++ b/app/utils.py
@@ -45,17 +45,17 @@ class utils:
         g = Github(access_token)
         self.repo = g.get_repo(repo_name)
 
-        self.existing_files = set()
-        for pr in g.search_issues(
+        self.existing_prs = g.search_issues(
             f"repo:{repo_name} is:pr base:main head:{self.bot_path}"
-        ):
-            self.existing_files.add(pr.title)
+        )
 
         self.start_date = None
         days = os.environ.get("DAYS")
         if days:
             self.start_date = datetime.now().date() - timedelta(days=int(days))
             print(f"Processing items since {self.start_date}.")
+
+        self.update_existing_pr = os.environ.get("UPDATE", "false").lower() == "true"
 
     def process_entry(self, entry):
         title = entry.get("title")
@@ -71,17 +71,29 @@ class utils:
             print(f"Skipping as it is older: {title}")
             return False
 
-        if any(link in pr_title for pr_title in self.existing_files):
-            print(f"Skipping as file already exists: {file_path} for {title}")
-            return False
-
-        print(f"Processing {file_path} from {title}")
-
-        branch_name = f"{file_path}-update-{datetime.now().strftime('%Y%m%d%H%M%S')}"
-        self.repo.create_git_ref(
-            ref=f"refs/heads/{branch_name}",
-            sha=self.repo.get_branch("main").commit.sha,
+        existing_pr_issue = next(
+            (pr for pr in self.existing_prs if link in pr.title),
+            None,
         )
+        existing_files = []
+        if existing_pr_issue:
+            if self.update_existing_pr and existing_pr_issue.state == "open":
+                print(f"Updating existing PR for {title}")
+                existing_pr = existing_pr_issue.as_pull_request()
+                branch_name = existing_pr.head.ref
+                existing_files = existing_pr.get_files()
+            else:
+                print(f"Skipping as file already exists: {file_path} for {title}")
+                return False
+        else:
+            print(f"Processing {file_path} from {title}")
+            branch_name = (
+                f"{file_path}-update-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+            )
+            self.repo.create_git_ref(
+                ref=f"refs/heads/{branch_name}",
+                sha=self.repo.get_branch("main").commit.sha,
+            )
 
         for group_name, media_list in config.get("media", {}).items():
             config_dict = {"media": media_list}
@@ -95,36 +107,59 @@ class utils:
             md_config = yaml.dump(config_dict, sort_keys=False)
             md_content = f"---\n{md_config}---\n{formatted_text}"
 
-            self.repo.create_file(
-                path=f"{file_path}-{group_name}.md",
-                message=f"Add {title} for {', '.join(media_list)}",
-                content=md_content,
-                branch=branch_name,
+            for existing_file in existing_files:
+                existing_filename = existing_file.filename
+                if group_name in existing_filename:
+                    file_on_repo = self.repo.get_contents(
+                        existing_filename, ref=branch_name
+                    )
+                    current_content = file_on_repo.decoded_content.decode("utf-8")
+                    if current_content.strip() != md_content.strip():
+                        self.repo.update_file(
+                            path=existing_filename,
+                            message=f"Update {title} for {', '.join(media_list)}",
+                            content=md_content,
+                            sha=existing_file.sha,
+                            branch=branch_name,
+                        )
+                        print(f"Updated existing file: {existing_filename} for {title}")
+                    else:
+                        print(
+                            f"No change detected in {existing_filename}, skipping update."
+                        )
+                    break
+            else:
+                self.repo.create_file(
+                    path=f"{file_path}-{group_name}.md",
+                    message=f"Add {title} for {', '.join(media_list)}",
+                    content=md_content,
+                    branch=branch_name,
+                )
+
+        if not existing_files:
+            pr_title = f"Update from {self.item_type}: {link}"
+            update_date = (
+                f"Update since {self.start_date.strftime('%Y-%m-%d')}\n\n"
+                if self.start_date
+                else ""
+            )
+            pr_body = (
+                f"This PR is created automatically by a {self.item_type} bot.\n"
+                f"{update_date}Processed:\n[{title}]({link})"
             )
 
-        pr_title = f"Update from {self.item_type}: {link}"
-        update_date = (
-            f"Update since {self.start_date.strftime('%Y-%m-%d')}\n\n"
-            if self.start_date
-            else ""
-        )
-        pr_body = (
-            f"This PR is created automatically by a {self.item_type} bot.\n"
-            f"{update_date}Processed:\n[{title}]({link})"
-        )
-
-        try:
-            pr = self.repo.create_pull(
-                title=pr_title,
-                body=pr_body,
-                base="main",
-                head=branch_name,
-            )
-            print(f"PR created: {pr.html_url}")
-            return True
-        except GithubException as e:
-            self.repo.get_git_ref(f"heads/{branch_name}").delete()
-            print(
-                f"Error in creating PR: {e.data.get('errors')[0].get('message')}\nRemoving branch {branch_name}"
-            )
-            return False
+            try:
+                pr = self.repo.create_pull(
+                    title=pr_title,
+                    body=pr_body,
+                    base="main",
+                    head=branch_name,
+                )
+                print(f"PR created: {pr.html_url}")
+                return True
+            except GithubException as e:
+                self.repo.get_git_ref(f"heads/{branch_name}").delete()
+                print(
+                    f"Error in creating PR: {e.data.get('errors')[0].get('message')}\nRemoving branch {branch_name}"
+                )
+                return False

--- a/config.yml
+++ b/config.yml
@@ -40,6 +40,46 @@ feeds:
         - EOSC
         - EuroScienceGateway
 
+json_feeds:
+  - title: "Galaxy Events"
+    url: https://galaxyproject.org/events/feed.json
+    list_key: "events"
+    format: "- {title}\n- {date}\n- {link}"
+
+    media:
+      - group1:
+        - mastodon-eu-freiburg
+        - matrix-eu-announce
+        - linkedin-galaxyproject
+      - group2:
+        - bluesky-galaxyproject
+
+    mentions:
+      mastodon-eu-freiburg:
+        - galaxyproject@mstdn.science
+      bluesky-galaxyproject:
+        - galaxyproject.bsky.social
+
+    hashtags:
+      mastodon-eu-freiburg:
+        - UseGalaxy
+        - GalaxyProject
+        - UniFreiburg
+        - EOSC
+        - EuroScienceGateway
+      bluesky-galaxyproject:
+        - UseGalaxy
+        - GalaxyProject
+        - UniFreiburg
+        - EOSC
+        - EuroScienceGateway
+      linkedin-galaxyproject:
+        - UseGalaxy
+        - GalaxyProject
+        - UniFreiburg
+        - EOSC
+        - EuroScienceGateway
+
 # youtube_channels:
 #   - channel: "https://www.youtube.com/c/galaxyproject"
 #     format: "🎥 New YouTube Video Released!\n\n{title}\n\n🔗 Watch it now: {link}"

--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,8 @@
-feeds:
-  - url: https://galaxyproject.org/eu/feed.atom
-
-    format: "📝 New blog post Released!\n{link}\n\n{content}"
+json_feeds:
+  - title: Galaxy News
+    url: https://galaxyproject.org/news/feed.json
+    list_key: "news"
+    format: "{tease}\n{link}"
 
     # Medias should get grouped if they need to be in same file or seperated
     # This is needed while in bluesky the characters are limited and we need
@@ -40,7 +41,6 @@ feeds:
         - EOSC
         - EuroScienceGateway
 
-json_feeds:
   - title: "Galaxy Events"
     url: https://galaxyproject.org/events/feed.json
     list_key: "events"

--- a/config.yml
+++ b/config.yml
@@ -42,6 +42,16 @@ json_feeds:
         linkedin-galaxyproject:
           - UseGalaxy
           - GalaxyProject
+      eu:
+        bluesky-galaxyproject:
+          - EOSC
+          - EuroScienceGateway
+        mastodon-galaxyproject:
+          - EOSC
+          - EuroScienceGateway
+        linkedin-galaxyproject:
+          - EOSC
+          - EuroScienceGateway
       freiburg:
         mastodon-eu-freiburg:
           - UniFreiburg
@@ -86,6 +96,16 @@ json_feeds:
         linkedin-galaxyproject:
           - UseGalaxy
           - GalaxyProject
+      eu:
+        bluesky-galaxyproject:
+          - EOSC
+          - EuroScienceGateway
+        mastodon-galaxyproject:
+          - EOSC
+          - EuroScienceGateway
+        linkedin-galaxyproject:
+          - EOSC
+          - EuroScienceGateway
       freiburg:
         mastodon-eu-freiburg:
           - UniFreiburg

--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,8 @@
 json_feeds:
-  - title: Galaxy News
+  - title: Galaxy Europe News
     url: https://galaxyproject.org/news/feed.json
     list_key: "news"
+    subsites: ["eu"]
     format: "{tease}\n{link}"
 
     # Medias should get grouped if they need to be in same file or seperated
@@ -41,9 +42,10 @@ json_feeds:
         - EOSC
         - EuroScienceGateway
 
-  - title: "Galaxy Events"
+  - title: "Galaxy Europe Events"
     url: https://galaxyproject.org/events/feed.json
     list_key: "events"
+    subsites: ["eu"]
     format: "- {title}\n- {date}\n- {link}"
 
     media:

--- a/config.yml
+++ b/config.yml
@@ -1,86 +1,106 @@
 json_feeds:
-  - title: Galaxy Europe News
+  - title: Galaxy News
     url: https://galaxyproject.org/news/feed.json
     list_key: "news"
-    subsites: ["eu"]
     format: "{tease}\n{link}"
 
     # Medias should get grouped if they need to be in same file or seperated
     # This is needed while in bluesky the characters are limited and we need
     # it to be seperated from the the main file to edit it seperately
     media:
-      - group1:
-        - mastodon-eu-freiburg
+      global:
+        group1:
+          - linkedin-galaxyproject
+        group2:
+          - bluesky-galaxyproject
+      eu:
         - matrix-eu-announce
-        - linkedin-galaxyproject
-      - group2:
-        - bluesky-galaxyproject
+        - mastodon-eu-freiburg
+      us:
+        - mastodon-galaxyproject
 
     mentions:
-      mastodon-eu-freiburg:
-        - galaxyproject@mstdn.science
-      bluesky-galaxyproject:
-        - galaxyproject.bsky.social
+      all:
+        mastodon-eu-freiburg:
+          - galaxyproject@mstdn.science
+        mastodon-galaxyproject:
+          - galaxyfreiburg@bawü.social
 
     hashtags:
-      mastodon-eu-freiburg:
-        - UseGalaxy
-        - GalaxyProject
-        - UniFreiburg
-        - EOSC
-        - EuroScienceGateway
-      bluesky-galaxyproject:
-        - UseGalaxy
-        - GalaxyProject
-        - UniFreiburg
-        - EOSC
-        - EuroScienceGateway
-      linkedin-galaxyproject:
-        - UseGalaxy
-        - GalaxyProject
-        - UniFreiburg
-        - EOSC
-        - EuroScienceGateway
+      all:
+        mastodon-eu-freiburg:
+          - UseGalaxy
+          - GalaxyProject
+          - EOSC
+          - EuroScienceGateway
+        mastodon-galaxyproject:
+          - UseGalaxy
+          - GalaxyProject
+          - EOSC
+          - EuroScienceGateway
+        bluesky-galaxyproject:
+          - UseGalaxy
+          - GalaxyProject
+          - EOSC
+          - EuroScienceGateway
+        linkedin-galaxyproject:
+          - UseGalaxy
+          - GalaxyProject
+          - EOSC
+          - EuroScienceGateway
+      freiburg:
+        mastodon-eu-freiburg:
+          - UniFreiburg
 
-  - title: "Galaxy Europe Events"
+  - title: "Galaxy Events"
     url: https://galaxyproject.org/events/feed.json
     list_key: "events"
-    subsites: ["eu"]
     format: "- {title}\n- {date}\n- {link}"
 
     media:
-      - group1:
+      global:
+        group1:
+          - linkedin-galaxyproject
+        group2:
+          - bluesky-galaxyproject
+      eu:
         - mastodon-eu-freiburg
         - matrix-eu-announce
-        - linkedin-galaxyproject
-      - group2:
-        - bluesky-galaxyproject
+      us:
+        - mastodon-galaxyproject
 
     mentions:
-      mastodon-eu-freiburg:
-        - galaxyproject@mstdn.science
-      bluesky-galaxyproject:
-        - galaxyproject.bsky.social
+      all:
+        mastodon-eu-freiburg:
+          - galaxyproject@mstdn.science
+        mastodon-galaxyproject:
+          - galaxyfreiburg@bawü.social
 
     hashtags:
-      mastodon-eu-freiburg:
-        - UseGalaxy
-        - GalaxyProject
-        - UniFreiburg
-        - EOSC
-        - EuroScienceGateway
-      bluesky-galaxyproject:
-        - UseGalaxy
-        - GalaxyProject
-        - UniFreiburg
-        - EOSC
-        - EuroScienceGateway
-      linkedin-galaxyproject:
-        - UseGalaxy
-        - GalaxyProject
-        - UniFreiburg
-        - EOSC
-        - EuroScienceGateway
+      all:
+        mastodon-eu-freiburg:
+          - UseGalaxy
+          - GalaxyProject
+          - EOSC
+          - EuroScienceGateway
+        mastodon-galaxyproject:
+          - UseGalaxy
+          - GalaxyProject
+          - EOSC
+          - EuroScienceGateway
+        bluesky-galaxyproject:
+          - UseGalaxy
+          - GalaxyProject
+          - EOSC
+          - EuroScienceGateway
+        linkedin-galaxyproject:
+          - UseGalaxy
+          - GalaxyProject
+          - EOSC
+          - EuroScienceGateway
+      freiburg:
+        mastodon-eu-freiburg:
+          - UniFreiburg
 
 # youtube_channels:
 #   - channel: "https://www.youtube.com/c/galaxyproject"

--- a/config.yml
+++ b/config.yml
@@ -36,18 +36,12 @@ json_feeds:
         mastodon-galaxyproject:
           - UseGalaxy
           - GalaxyProject
-          - EOSC
-          - EuroScienceGateway
         bluesky-galaxyproject:
           - UseGalaxy
           - GalaxyProject
-          - EOSC
-          - EuroScienceGateway
         linkedin-galaxyproject:
           - UseGalaxy
           - GalaxyProject
-          - EOSC
-          - EuroScienceGateway
       freiburg:
         mastodon-eu-freiburg:
           - UniFreiburg
@@ -86,18 +80,12 @@ json_feeds:
         mastodon-galaxyproject:
           - UseGalaxy
           - GalaxyProject
-          - EOSC
-          - EuroScienceGateway
         bluesky-galaxyproject:
           - UseGalaxy
           - GalaxyProject
-          - EOSC
-          - EuroScienceGateway
         linkedin-galaxyproject:
           - UseGalaxy
           - GalaxyProject
-          - EOSC
-          - EuroScienceGateway
       freiburg:
         mastodon-eu-freiburg:
           - UniFreiburg


### PR DESCRIPTION
Introduce functionality to process JSON feeds, including a new script and configuration for handling feed data. This enhancement allows for better integration of JSON-based content into the existing system.

As requested in https://github.com/usegalaxy-eu/galaxy-social/issues/213, after the PR has been merged it will retrive ALL the events that are not passed from https://galaxyproject.org/events/feed.json and send new events to the galaxy social bot as new PRs.