### PR TITLE
Refactor link generation logic in JSON bot for improved URL handling

### DIFF
--- a/app/json_bot.py
+++ b/app/json_bot.py
@@ -52,13 +52,12 @@ def main():
             if "external_url" in entry:
                 entry["link"] = entry["external_url"]
             else:
-                if "://" in url:
-                    protocol = url.split("://")[0] + "://"
-                    url = url.split("://")[1]
-                else:
-                    protocol = "http://"
-                path = path if path.startswith("/") else f"/{path}"
-                entry["link"] = protocol + url.split("/")[0] + path
+                protocol, new_url = (
+                    url.split("://", 1) if "://" in url else ("http", url)
+                )
+                domain = new_url.split("/", 1)[0]
+                path = f"/{path.lstrip('/')}"
+                entry["link"] = f"{protocol}://{domain}{path}"
 
             if feed_list_key == "events":
                 if entry.get("days_ago") > 0:

--- a/app/json_bot.py
+++ b/app/json_bot.py
@@ -1,5 +1,6 @@
 import json
 import os
+from urllib.parse import urlsplit
 
 import requests
 from dateutil import parser
@@ -52,12 +53,11 @@ def main():
             if "external_url" in entry:
                 entry["link"] = entry["external_url"]
             else:
-                protocol, new_url = (
-                    url.split("://", 1) if "://" in url else ("http", url)
-                )
-                domain = new_url.split("/", 1)[0]
-                path = f"/{path.lstrip('/')}"
-                entry["link"] = f"{protocol}://{domain}{path}"
+                parsed_url = urlsplit(url)
+                protocol = parsed_url.scheme or "http"
+                domain = parsed_url.netloc or parsed_url.path.split("/")[0]
+                normalized_path = f"/{path.lstrip('/')}"
+                entry["link"] = f"{protocol}://{domain}{normalized_path}"
 
             if feed_list_key == "events":
                 if entry.get("days_ago") > 0:


### PR DESCRIPTION
The newly generated URLS have a problem with the protocol and use `http://` instead of `https://`, causing duplicated posts.
This will fix it to use the same URL as inputted in the config.