### PR TITLE
Add GTN feed

### DIFF
--- a/.github/workflows/feed_bot.yml
+++ b/.github/workflows/feed_bot.yml
@@ -2,7 +2,7 @@ name: Create PR for RSS/Atom or json feeds
 
 on:
   schedule:
-    - cron: "00 00 * * *"
+    - cron: "0 0,8,16 * * *"
 
   workflow_dispatch:
     inputs:

--- a/app/feed_bot.py
+++ b/app/feed_bot.py
@@ -21,6 +21,7 @@ def main():
             print(f"Error in parsing feed {feed.get('url')}: {e}")
             continue
 
+        excluded_tags = feed.get("excluded_tags", [])
         folder = feed.get("title", feed_data.feed.title).replace(" ", "_").lower()
         format_string = feed.get("format")
         for entry in feed_data.entries:
@@ -31,6 +32,10 @@ def main():
 
             if entry.get("link") is None:
                 print(f"No link found: {entry.get('title')}")
+                continue
+
+            if any(tag.get("term") in excluded_tags for tag in entry.get("tags", [])):
+                print(f"Skipping {entry.get('title')} as it is in the excluded tags")
                 continue
 
             file_name = (

--- a/app/json_bot.py
+++ b/app/json_bot.py
@@ -33,8 +33,8 @@ def main():
         folder = feed_title.replace(" ", "_").lower()
         format_string = feed.get("format")
         media_data = feed.get("media")
-        mentions_data = feed.get("mentions")
-        hashtags_data = feed.get("hashtags")
+        mentions_data = feed.get("mentions", {})
+        hashtags_data = feed.get("hashtags", {})
 
         for entry in feed_data.get(feed_list_key, []):
             entry_subsites = entry.get("subsites")

--- a/app/utils.py
+++ b/app/utils.py
@@ -71,6 +71,7 @@ class utils:
         rel_file_path = entry.get("rel_file_path")
         formatted_text = entry.get("formatted_text")
         link = entry.get("link")
+        external_url = entry.get("external_url")
 
         file_path = f"{self.bot_path}/{rel_file_path}"
 
@@ -80,9 +81,16 @@ class utils:
 
         existing_pr_issue = None
         for pr in self.existing_prs:
-            if link.lower() in pr.title.lower():
-                existing_pr_issue = pr
+            pr_title = pr.title.lower()
+            for url in [link, external_url]:
+                if isinstance(url, str):
+                    url = url.strip().lower()
+                    if url and url in pr_title:
+                        existing_pr_issue = pr
+                        break
+            if existing_pr_issue:
                 break
+
         existing_files = []
         if existing_pr_issue:
             if self.update_existing_pr and existing_pr_issue.state == "open":

--- a/config.yml
+++ b/config.yml
@@ -14,6 +14,9 @@ feeds:
   - title: GTN Events
     url: https://training.galaxyproject.org/training-material/events/feed.xml
     format: "{title}\n{link}"
+    # This is a special case where we want to exclude the events having event-external tag
+    excluded_tags:
+      - "event-external"
 
     media:
       - linkedin-galaxyproject

--- a/config.yml
+++ b/config.yml
@@ -1,3 +1,28 @@
+feeds:
+  - title: GTN News
+    url: https://training.galaxyproject.org/training-material/feed.xml
+    format: "{summary}\n{link}"
+
+    media:
+      - linkedin-galaxyproject
+
+    hashtags:
+      linkedin-galaxyproject:
+        - UseGalaxy
+        - GalaxyProject
+
+  - title: GTN Events
+    url: https://training.galaxyproject.org/training-material/events/feed.xml
+    format: "{title}\n{link}"
+
+    media:
+      - linkedin-galaxyproject
+
+    hashtags:
+      linkedin-galaxyproject:
+        - UseGalaxy
+        - GalaxyProject
+
 json_feeds:
   - title: Galaxy News
     url: https://galaxyproject.org/news/feed.json


### PR DESCRIPTION
@teresa-m suggested finding a way to quickly share GTN news and events. Here are the updates:
Added GTN feed for faster social media posts (only to LinkedIn), using the format `{summary}\n{link}` for news and `{title}\n{link}` for events.
Implemented support for external URLs to prevent duplicate posts when posting from Galaxy hub.
Updated cron schedule for the feed bot workflow to run 3 times a day.

| **UTC** | **CET** | **PST** |
|---------|---------|---------|
| 00:00   | 02:00   | 17:00   |
| 08:00   | 10:00   | 01:00   |
| 16:00   | 18:00   | 09:00   |

Improve handling of mentions, hashtags, and URLs in the entry processing logic.