### PR TITLE
Update cron schedule for feed generation

### DIFF
--- a/.github/workflows/feed_bot.yml
+++ b/.github/workflows/feed_bot.yml
@@ -2,7 +2,7 @@ name: Create PR for RSS/Atom or json feeds
 
 on:
   schedule:
-    - cron: "00 00 * * *"
+    - cron: "0 0,8,16 * * *"
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Change the cron schedule to run at 0, 8, and 16 hours for improved feed generation frequency.

| **UTC** | **CET** | **PST** |
|---------|---------|---------|
| 00:00   | 02:00   | 17:00   |
| 08:00   | 10:00   | 01:00   |
| 16:00   | 18:00   | 09:00   |