### PR TITLE
Galaxy Hub feed update

### DIFF
--- a/.github/workflows/feed_bot.yml
+++ b/.github/workflows/feed_bot.yml
@@ -14,6 +14,9 @@ on:
         description: "Update the open PRs with new json formats"
         required: false
         type: boolean
+      
+  repository_dispatch:
+    types: [feed-updated]
 
 jobs:
   feed-bot:


### PR DESCRIPTION
Introduce a `repository_dispatch` event to handle feed updates more effectively.
Related to https://github.com/galaxyproject/galaxy-hub/pull/3388