### PR TITLE
Remove event filtering for entries older than 14 days

### DIFF
--- a/app/json_bot.py
+++ b/app/json_bot.py
@@ -64,11 +64,6 @@ def main():
                 if entry.get("days_ago") > 0:
                     print(f"Skipping {entry.get('title')} as it is past the date")
                     continue
-                if entry.get("days_ago") < -14:
-                    print(
-                        f"Skipping {entry.get('title')} as it is more than 14 days till now"
-                    )
-                    continue
 
             content = entry.get("content", "").strip()
             entry["content"] = markdownify(content)


### PR DESCRIPTION
Eliminate the restriction that skips entries older than 14 days, allowing all entries to be processed regardless of their age.