### PR TITLE
Fix None rendered as string in json_bot when feed field is null

### DIFF
--- a/app/json_bot.py
+++ b/app/json_bot.py
@@ -86,7 +86,12 @@ def main():
 
             entry["location"] = entry.get("location", {}).get("name") or ""
 
-            safe_entry = {k: ("" if v is None else v) for k, v in entry.items()}
+            safe_entry = {}
+            for key, value in entry.items():
+                if value is None:
+                    safe_entry[key] = ""
+                else:
+                    safe_entry[key] = value
             formatted_text = format_string.format(**safe_entry)
             formatted_text = re.sub(r"\n{3,}", "\n\n", formatted_text).strip()
 

--- a/app/json_bot.py
+++ b/app/json_bot.py
@@ -86,7 +86,8 @@ def main():
 
             entry["location"] = entry.get("location", {}).get("name") or ""
 
-            formatted_text = format_string.format(**entry)
+            safe_entry = {k: ("" if v is None else v) for k, v in entry.items()}
+            formatted_text = format_string.format(**safe_entry)
             formatted_text = re.sub(r"\n{3,}", "\n\n", formatted_text).strip()
 
             new_media = {}


### PR DESCRIPTION
When a feed entry has a null field (e.g. `tease: null` in `galaxyproject.org/events/feed.json`), Python's `str.format()` renders it as the literal string `"None"`, which leaks into the generated post.

Spotted in #682 — all 4 generated posts had a bare `None` line between the event title and the location/date block.

**Fix:** coerce `None` values to `""` before formatting.