### PR TITLE
Update dependencies, add Dependabot, modernize feed_bot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "UTC"
+      interval: "monthly"
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
@@ -32,10 +29,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "UTC"
+      interval: "monthly"
     open-pull-requests-limit: 10
     groups:
       actions:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+
+updates:
+  # ── Python pip dependencies ──────────────────────────────────────────
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      python-minor-patch:
+        applies-to: "version-updates"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "python"
+      - "dependencies"
+
+  # ── GitHub Actions ───────────────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "github-actions"
+      - "dependencies"

--- a/.github/workflows/feed_bot.yml
+++ b/.github/workflows/feed_bot.yml
@@ -23,23 +23,22 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.13"
+          cache: "pip"
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
+        run: pip install -r requirements.txt
 
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: "usegalaxy-eu"
           repositories: "galaxy-social"
@@ -65,7 +64,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Keep the repository alive
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-feedparser
-PyYAML
-PyGithub
-pytube
-python-dateutil
-pyzotero
-markdownify
-beautifulsoup4
+feedparser==6.0.12
+PyYAML==6.0.3
+PyGithub==2.9.1
+pytube==15.0.0
+python-dateutil==2.9.0.post0
+pyzotero==1.11.1
+markdownify==1.2.2
+beautifulsoup4==4.14.3


### PR DESCRIPTION
## Summary

- Pin all 8 dependencies to specific versions in `requirements.txt`
- Add `.github/dependabot.yml` for pip + github-actions (weekly, grouped minor/patch, cooldown)
- Update `feed_bot.yml`: bump actions to v6/v3, Python 3.13, pip caching, `client-id` replaces deprecated `app-id`