### PR TITLE
Harden GitHub Actions workflows with zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,11 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       actions:
         patterns:

--- a/.github/workflows/citation_bot.yml
+++ b/.github/workflows/citation_bot.yml
@@ -11,6 +11,8 @@ on:
         required: false
         default: "5"
 
+permissions: {}
+
 jobs:
   citation-bot:
     runs-on: ubuntu-latest
@@ -20,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -38,6 +42,8 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: "usegalaxy-eu"
           repositories: "galaxy-social"
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Run python script
         env:

--- a/.github/workflows/feed_bot.yml
+++ b/.github/workflows/feed_bot.yml
@@ -15,6 +15,8 @@ on:
         required: false
         type: boolean
 
+permissions: {}
+
 jobs:
   feed-bot:
     runs-on: ubuntu-latest
@@ -24,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -42,6 +46,8 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: "usegalaxy-eu"
           repositories: "galaxy-social"
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Run python script for RSS/Atom feeds
         env:
@@ -65,6 +71,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Keep the repository alive
         run: |

--- a/.github/workflows/youtube_bot.yml
+++ b/.github/workflows/youtube_bot.yml
@@ -11,6 +11,8 @@ on:
         required: false
         default: "5"
 
+permissions: {}
+
 jobs:
   youtube-bot:
     runs-on: ubuntu-latest
@@ -20,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -38,6 +42,8 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: "usegalaxy-eu"
           repositories: "galaxy-social"
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Run python script
         env:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,31 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/*'
+  pull_request:
+    paths:
+      - '.github/workflows/*'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: false

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        '*': ref-pin


### PR DESCRIPTION
Apply zizmor security best practices to all workflows.

See https://docs.zizmor.sh/

- Add top-level permissions: {} to restrict default GITHUB_TOKEN scope
- Add persist-credentials: false to checkout steps
- Run zizmor-action on changes to GitHub workflows